### PR TITLE
Align Flask dependency automation and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,64 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  python:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        app:
+          - flask-auth-dash-bootstrap
+          - flask-bootstrap
+          - flask-connextion-rest
+    defaults:
+      run:
+        working-directory: ${{ matrix.app }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.14"
+          cache: pip
+          cache-dependency-path: ${{ matrix.app }}/requirements.txt
+      - run: python -m pip install --disable-pip-version-check -r requirements.txt
+      - run: python -m pip check
+      - run: python -m pytest -q
+      - run: python -m pip install --disable-pip-version-check pip-audit==2.10.1
+      - run: python -m pip_audit -r requirements.txt
+
+  mongo-celery:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.14"
+          cache: pip
+          cache-dependency-path: flask-mongo-celery/requirements.txt
+      - run: python -m pip install --disable-pip-version-check pip-audit==2.10.1
+      - run: python -m pip_audit -r requirements.txt
+        working-directory: flask-mongo-celery
+      - run: docker build --tag flask-mongo-celery:test .
+        working-directory: flask-mongo-celery
+      - run: docker run --rm flask-mongo-celery:test python -m pytest -q
+
+  renovate-config:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+      - run: npx --yes --package renovate renovate-config-validator renovate.json

--- a/README.md
+++ b/README.md
@@ -1,67 +1,108 @@
 # Flask Apps
 
-> A huge folder where I could store flask template applications.
+A collection of independent Flask service and application starters. Each
+top-level directory is its own runnable example; this repository is not one
+installable monolith.
 
-## Overview
+## Example inventory
 
-Currently I use Flask in multiple situations:
+| Directory | Purpose | Runtime status |
+| --- | --- | --- |
+| `flask-auth-dash-bootstrap` | Flask authentication around an embedded Dash app | Python 3.14, locked and tested |
+| `flask-bootstrap` | Server-rendered Flask application with authentication and admin views | Python 3.14, locked and tested; frontend remains Bootstrap 4 |
+| `flask-connextion-rest` | Connexion/OpenAPI people and notes CRUD service | Python 3.14, locked and tested |
+| `flask-mongo-celery` | Flask, MongoDB, Celery, and browser-scraping example | Python 3.14, locked and container-tested |
+| `flask-auth` | Small authentication-webhook prototype | Legacy; modernization required |
+| `flask-dash-bootstrap` | Dash and Bootstrap prototype | Legacy Python 3.9/Pipenv |
+| `flask-graphene-sqlalchemy` | GraphQL and SQLAlchemy prototype | Legacy Python 3.9/Pipenv |
+| `flask-sql-celery` | SQL-backed Celery deployment prototype | Legacy Python 3.9.5/Pipenv |
 
-- Need a RESTful API for my Next.js app.
-- Need a GraphQL API for my Gatsby.js app.
-- Need to persistent data and have long running processes compute datasets.
-- Need to create a server HTML app over basics forms.
-- Need to create a Dash/Plot.ly dashboard for presenting some analysis.
-- etc.
+“Legacy” means the directory is preserved as a reference and is not covered by
+the repository CI matrix. Do not infer current production readiness from its
+presence here.
 
-I've created a series folders as starters with my past Flask use.
+## Working with an example
 
-## Features
+Read the example's own README first. For one of the Python 3.14 examples, the
+usual local flow is:
 
-Its not just Flask but an ecosystem to properly create a RESTful API service:
+```sh
+cd flask-connextion-rest
+python3.14 -m venv .venv
+source .venv/bin/activate
+python -m pip install -r requirements.txt
+python -m pytest -q
+```
 
-- [Flask](https://flask.palletsprojects.com/en/1.1.x/) is a lightweight WSGI web application framework in Python. It is designed to make getting started very quickly and very easily.
-- [Connexion](https://connexion.readthedocs.io/en/latest/index.html) is a framework on top of Flask that automatically handles HTTP requests defined using OpenAPI (formerly known as Swagger), supporting both v2.0 and v3.0 of the specification.
-- [Graphene](https://github.com/graphql-python/graphene)
-- [marshmallow](https://marshmallow.readthedocs.io/en/stable/) is an ORM/ODM/framework-agnostic library for converting complex datatypes, such as objects, to and from native Python datatypes.
-- [Flask-Marshmallow](https://flask-marshmallow.readthedocs.io/en/latest/) is a thin integration layer for Flask and marshmallow that adds additional features to marshmallow.
-- [SQLAlchemy](https://www.sqlalchemy.org/library.html) is the Python SQL toolkit and Object Relational Mapper that gives application developers the full power and flexibility of SQL.
-- [Flask-SQLAlchemy](https://flask-sqlalchemy.palletsprojects.com/en/2.x/) is an extension for Flask that adds support for SQLAlchemy to your application. It aims to simplify using SQLAlchemy with Flask.
-- [Alembic](http://alembic.zzzcomputing.com/)
-- [PyMongo](https://pymongo.readthedocs.io/en/stable/index.html) is a Python distribution containing tools for working with MongoDB, and is the recommended way to work with MongoDB from Python.
-- [Flask-PyMongo](https://flask-pymongo.readthedocs.io/en/latest/)
-- [Celery](https://docs.celeryproject.org/en/latest/index.html) is a simple, flexible, and reliable distributed system to process vast amounts of messages, while providing operations with the tools required to maintain such a system. It’s a task queue with focus on real-time processing, while also supporting task scheduling.
+Each example owns its environment variables, database behavior, ports, and
+startup command. Do not install every `requirements.txt` into one environment;
+the examples intentionally have different dependency graphs.
 
-This project integrates other Flask libraries using:
+## Validation
 
-- [Blueprints](https://flask.palletsprojects.com/en/1.0.x/blueprints/) for scalability.
-- [flask_login](https://flask-login.readthedocs.io/en/latest/) for the login system (passwords hashed with bcrypt).
-- [Flask-Script](https://flask-script.readthedocs.io/)
-- [Flask-User](http://flask-user.readthedocs.io/en/v0.6/)
+GitHub Actions runs the supported examples independently:
 
-## Links
+- Python 3.14 clean installs, `pip check`, pytest, and advisory audits for the
+  authentication, Bootstrap, and Connexion examples.
+- A production-image build and containerized browser/test run for
+  `flask-mongo-celery`, plus an audit of its lock.
+- Renovate configuration validation.
 
-- https://flask.palletsprojects.com/en/1.1.x/
-- https://github.com/humiaozuzu/awesome-flask#readme
+When changing a legacy example, add a focused validation gate for that directory
+before treating a dependency update as mergeable.
 
-### Learn
+## Dependency contract
 
-- https://flask.palletsprojects.com/en/1.1.x/api/#api
-- https://blog.miguelgrinberg.com/post/the-flask-mega-tutorial-part-i-hello-world
-- https://blog.appseed.us/flask-how-to-code-simple-tasks/
+Four modern examples use `pip-compile`:
 
-## Server Architecture
+```text
+requirements.in  -> direct dependency intent
+requirements.txt -> generated, fully resolved lock
+```
 
-YES!!!
+Edit the `.in` file and regenerate its matching lock with Python 3.14:
 
-## 🤝 Contributing
+```sh
+python -m pip install pip-tools pip-audit==2.10.1
+pip-compile --upgrade --resolver=backtracking --strip-extras \
+  --output-file=requirements.txt requirements.in
+python -m pip check
+python -m pytest -q
+python -m pip_audit -r requirements.txt
+```
 
-1. Fork this repository;
-2. Create your branch: `git checkout -b my-new-feature`;
-3. Commit your changes: `git commit -m 'Add some feature'`;
-4. Push to the branch: `git push origin my-new-feature`.
+Renovate is configured to update those source files through its `pip-compile`
+manager. Direct edits to transitive pins in generated `requirements.txt` files
+are disabled because they can violate exact dependency constraints.
 
-**After your pull request is merged**, you can safely delete your branch.
+The `flask-bootstrap` templates still load Bootstrap 4. Popper 2 updates are
+held until that template and data-attribute migration is performed as one
+browser-tested Bootstrap 5 change. Bootstrap 4 expects the Popper 1 dependency
+line; merely changing the CDN URL to a newer Popper 2 release is not compatible.
 
-## 📝 License
+The raw requirement files in legacy examples remain independently managed until
+those directories are migrated to a reproducible lock format.
 
-This project is licensed under the MIT License - see the [LICENSE.md](LICENSE.md) file for more information.
+## Repository layout
+
+Each example generally contains some combination of:
+
+```text
+app/ or app.py       Flask application code
+requirements.in      Direct Python dependency pins
+requirements.txt     Installed or generated dependency set
+Dockerfile           Container runtime contract
+test/ or tests/      Example-local validation
+README.md             Example-local setup and limitations
+```
+
+## Contributing
+
+Keep pull requests scoped to one example or one repository-wide maintenance
+contract. State which examples were exercised, preserve generated-lock
+provenance, and do not use a passing test from one directory as evidence for
+another.
+
+## License
+
+See [LICENSE.md](./LICENSE.md).

--- a/flask-bootstrap/requirements.in
+++ b/flask-bootstrap/requirements.in
@@ -1,6 +1,7 @@
 Flask==3.1.3
 Flask-Migrate==4.1.0
-Flask-Security-Too[common]==5.8.1
+# 5.8.0-5.8.1 are affected by GHSA-f66q-9rf6-8795; revisit when a fixed release exists.
+Flask-Security-Too[common]==5.7.1
 Flask-SQLAlchemy==3.1.1
 Flask-WTF==1.3.0
 gunicorn==26.0.0

--- a/flask-bootstrap/requirements.txt
+++ b/flask-bootstrap/requirements.txt
@@ -47,7 +47,7 @@ flask-migrate==4.1.0
     # via -r requirements.in
 flask-principal==0.4.0
     # via flask-security-too
-flask-security-too==5.8.1
+flask-security-too==5.7.1
     # via
     #   -r requirements.in
     #   flask-security-too
@@ -59,8 +59,6 @@ flask-wtf==1.3.0
     # via
     #   -r requirements.in
     #   flask-security-too
-greenlet==3.5.4
-    # via sqlalchemy
 gunicorn==26.0.0
     # via -r requirements.in
 idna==3.18

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,27 @@
 {
-  "extends": [
-    "config:base"
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "pip-compile": {
+    "managerFilePatterns": ["/(^|/)requirements\\.txt$/"]
+  },
+  "packageRules": [
+    {
+      "description": "Update generated Python locks through their requirements.in inputs",
+      "matchManagers": ["pip_requirements"],
+      "matchFileNames": [
+        "flask-auth-dash-bootstrap/requirements.txt",
+        "flask-bootstrap/requirements.txt",
+        "flask-connextion-rest/requirements.txt",
+        "flask-mongo-celery/requirements.txt"
+      ],
+      "enabled": false
+    },
+    {
+      "description": "Hold Popper 2 until the Flask Bootstrap templates migrate from Bootstrap 4",
+      "matchManagers": ["html"],
+      "matchFileNames": ["flask-bootstrap/app/templates/*.html"],
+      "matchPackageNames": ["popper.js"],
+      "enabled": false
+    }
   ]
 }


### PR DESCRIPTION
## What changed

- replace the deprecated Renovate base preset with `config:recommended` and schema validation
- activate Renovate's `pip-compile` manager for generated Python locks
- prevent direct `pip_requirements` edits to the four generated `requirements.txt` files
- hold Popper 2 updates on the Bootstrap 4 templates until a deliberate Bootstrap 5 migration
- add a pinned GitHub Actions matrix for the three directly runnable Python 3.14 examples
- add a container build, browser test, and advisory audit for `flask-mongo-celery`
- add a Renovate configuration validation job
- replace the root README with an accurate example inventory, support boundary, validation matrix, and lockfile contract
- move `Flask-Security-Too[common]` from 5.8.1 to 5.7.1 because 5.8.0-5.8.1 are affected by GHSA-f66q-9rf6-8795 and no fixed release is currently listed
- regenerate the Flask Bootstrap lock from `requirements.in`

## Why

The repository had no GitHub checks. Renovate treated generated pip-compile output as ordinary requirements and opened PR #167 that violated Pydantic 2.13.4's exact `pydantic-core==2.46.4` requirement. It also opened PR #166 for Popper 2.11.8 under Bootstrap 4.0, even though Bootstrap 4 uses the Popper 1 dependency line. Both invalid PRs were closed with evidence.

A current advisory audit then found GHSA-f66q-9rf6-8795 in Flask-Security-Too 5.8.1. The lock now uses the unaffected 5.7.1 line pending a fixed upstream release.

## Local validation

Validated commit: `d3ba02f`

- Renovate CLI configuration validator: passed
- workflow YAML and Renovate JSON parse: passed
- Python 3.14 clean installs: passed for all three host-test matrix examples
- `pip check`: passed for all three examples
- `flask-auth-dash-bootstrap`: 3 passed
- `flask-bootstrap`: 1 passed after the security downgrade
- `flask-connextion-rest`: 2 passed
- pip-audit: no known vulnerabilities in all four generated locks
- `git diff --check`: passed

Docker Desktop is not running on the local machine, so the exact container build and Chromium-backed Mongo/Celery tests are intentionally delegated to this PR's GitHub Actions job. Do not merge until every exact-head job passes.

## Scope boundary

This PR does not modernize the four legacy Python 3.9/Pipenv examples and does not migrate the Bootstrap 4 templates to Bootstrap 5. Those are separate behavior changes requiring their own runtime and browser gates.

It does not deploy any service.

## Review focus

- manager/file matching in `renovate.json`
- generated-lock provenance
- the Flask-Security-Too temporary security downgrade
- CI working directories and container test
- whether the support/legacy labels in the root README match intended ownership

## Rollback

Revert this PR to restore the prior Renovate behavior. Reopening #166 or #167 without their respective Bootstrap migration or lock regeneration would reintroduce the documented incompatibilities.