### PR TITLE
Enforce Connexion API write contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ together.
 | --- | --- | --- |
 | [`flask-auth-dash-bootstrap`](flask-auth-dash-bootstrap/) | Flask authentication, SQLAlchemy, migrations, and an embedded Dash application | Python install, dependency check, pytest, and security audit |
 | [`flask-bootstrap`](flask-bootstrap/) | Server-rendered Flask application with user and administration flows | Python install, dependency check, pytest, and security audit |
-| [`flask-connextion-rest`](flask-connextion-rest/) | Connexion/OpenAPI API with Flask, SQLAlchemy, and Marshmallow | Python install, dependency check, contract tests, and security audit |
+| [`flask-connextion-rest`](flask-connextion-rest/) | Connexion/OpenAPI API with request, response, and persistence constraints across Flask, SQLAlchemy, and Marshmallow | Python install, dependency check, OpenAPI and contract tests, and security audit |
 | [`flask-mongo-celery`](flask-mongo-celery/) | Flask, MongoDB-oriented data access, and Celery background work | Dependency audit plus container build and containerized tests |
 | [`flask-sql-celery`](flask-sql-celery/) | Flask, SQLAlchemy, Celery, and a composed service stack | Python tests, dependency audit, Compose validation, build, startup, and health check |
 
@@ -100,7 +100,7 @@ not evidence that another sample or an archival directory is supported.
 
 - Keep application dependencies isolated; do not introduce a repository-wide Python environment.
 - Keep OpenAPI, request validation, persistence, and serialization boundaries explicit in API
-  samples.
+  samples; update those contracts together.
 - Exercise worker-backed applications through their container or Compose boundary, not only unit
   tests that bypass infrastructure.
 - Treat `requirements.txt` as a generated, reviewable artifact and audit the exact lock that ships.

--- a/flask-connextion-rest/README.md
+++ b/flask-connextion-rest/README.md
@@ -2,7 +2,19 @@
 
 This example runs on Python 3.14 with Connexion 3, Flask 3, SQLAlchemy 2,
 and Marshmallow 4. The OpenAPI contract owns the JSON API under `/api`, while
-Flask renders the example pages.
+Flask renders the example pages. Connexion validates request payloads and
+successful responses against that contract; SQLAlchemy independently enforces
+the required persistence fields.
+
+## API contract
+
+- Person creation requires `fname` and `lname`; each value is 1–32 characters.
+- Person updates require at least one recognized name field.
+- Note creation and updates require non-empty `content`.
+- Undeclared request properties are rejected instead of being silently ignored.
+
+Keep `swagger.yml`, the SQLAlchemy model constraints, and contract tests aligned
+when changing a write payload.
 
 ## Local use
 
@@ -24,6 +36,7 @@ docker run --rm -p 5000:5000 flask-connexion-rest
 ```bash
 python -m pytest -q
 python -m compileall -q .
+python -m openapi_spec_validator swagger.yml
 ```
 
 Edit direct pins in `requirements.in`, then regenerate the Python 3.14 lock:

--- a/flask-connextion-rest/models.py
+++ b/flask-connextion-rest/models.py
@@ -16,9 +16,14 @@ class Person(db.Model):
     __tablename__ = "person"
 
     person_id = db.Column(db.Integer, primary_key=True)
-    lname = db.Column(db.String(32))
-    fname = db.Column(db.String(32))
-    timestamp = db.Column(db.DateTime, default=utc_now, onupdate=utc_now)
+    lname = db.Column(db.String(32), nullable=False)
+    fname = db.Column(db.String(32), nullable=False)
+    timestamp = db.Column(
+        db.DateTime,
+        default=utc_now,
+        onupdate=utc_now,
+        nullable=False,
+    )
     notes = db.relationship(
         "Note",
         backref="person",
@@ -32,9 +37,18 @@ class Note(db.Model):
     __tablename__ = "note"
 
     note_id = db.Column(db.Integer, primary_key=True)
-    person_id = db.Column(db.Integer, db.ForeignKey("person.person_id"))
+    person_id = db.Column(
+        db.Integer,
+        db.ForeignKey("person.person_id"),
+        nullable=False,
+    )
     content = db.Column(db.String, nullable=False)
-    timestamp = db.Column(db.DateTime, default=utc_now, onupdate=utc_now)
+    timestamp = db.Column(
+        db.DateTime,
+        default=utc_now,
+        onupdate=utc_now,
+        nullable=False,
+    )
 
 
 class PersonNoteSchema(Schema):
@@ -67,4 +81,5 @@ class NoteSchema(ma.SQLAlchemyAutoSchema):
         load_instance = True
         sqla_session = db.session
 
+    person_id = fields.Int(dump_only=True)
     person = fields.Nested(NotePersonSchema, dump_default=None)

--- a/flask-connextion-rest/notes.py
+++ b/flask-connextion-rest/notes.py
@@ -3,7 +3,7 @@ This is the people module and supports all the REST actions for the
 people data
 """
 
-from flask import make_response, abort
+from flask import abort
 from config import db
 from models import Person, Note, NoteSchema
 
@@ -140,9 +140,7 @@ def delete(person_id, note_id):
     if note is not None:
         db.session.delete(note)
         db.session.commit()
-        return make_response(
-            "Note {note_id} deleted".format(note_id=note_id), 200
-        )
+        return {"message": f"Note {note_id} deleted"}, 200
 
     # Otherwise, nope, didn't find that note
     else:

--- a/flask-connextion-rest/people.py
+++ b/flask-connextion-rest/people.py
@@ -3,7 +3,7 @@ This is the people module and supports all the REST actions for the
 people data
 """
 
-from flask import make_response, abort
+from flask import abort
 from config import db
 from models import Person, PersonSchema, Note
 
@@ -140,7 +140,7 @@ def delete(person_id):
     if person is not None:
         db.session.delete(person)
         db.session.commit()
-        return make_response(f"Person {person_id} deleted", 200)
+        return {"message": f"Person {person_id} deleted"}, 200
 
     # Otherwise, nope, didn't find that person
     else:

--- a/flask-connextion-rest/server.py
+++ b/flask-connextion-rest/server.py
@@ -11,7 +11,11 @@ def create_app(extra_config=None):
     connexion_app = connexion.FlaskApp(__name__, specification_dir=basedir)
     app = connexion_app.app
     configure_app(app, extra_config)
-    connexion_app.add_api("swagger.yml")
+    connexion_app.add_api(
+        "swagger.yml",
+        strict_validation=True,
+        validate_responses=True,
+    )
 
     # Import model metadata before creating the sample application's tables.
     import models  # noqa: F401

--- a/flask-connextion-rest/swagger.yml
+++ b/flask-connextion-rest/swagger.yml
@@ -1,14 +1,67 @@
 swagger: "2.0"
 info:
-  description: This is the swagger file that goes with our server code
-  version: "1.0.0"
-  title: Swagger Rest Article
+  description: Contract for the people and notes reference API.
+  version: "1.1.0"
+  title: Flask Connexion People API
 consumes:
   - application/json
 produces:
   - application/json
 
 basePath: /api
+
+definitions:
+  PersonCreate:
+    type: object
+    additionalProperties: false
+    required:
+      - fname
+      - lname
+    properties:
+      fname:
+        type: string
+        minLength: 1
+        maxLength: 32
+        description: First name of the person.
+      lname:
+        type: string
+        minLength: 1
+        maxLength: 32
+        description: Last name of the person.
+  PersonUpdate:
+    type: object
+    additionalProperties: false
+    minProperties: 1
+    properties:
+      fname:
+        type: string
+        minLength: 1
+        maxLength: 32
+        description: Updated first name of the person.
+      lname:
+        type: string
+        minLength: 1
+        maxLength: 32
+        description: Updated last name of the person.
+  NoteWrite:
+    type: object
+    additionalProperties: false
+    required:
+      - content
+    properties:
+      content:
+        type: string
+        minLength: 1
+        description: Text content of the note.
+  DeleteResponse:
+    type: object
+    additionalProperties: false
+    required:
+      - message
+    properties:
+      message:
+        type: string
+        description: Confirmation that the resource was deleted.
 
 # Paths supported by the server application
 paths:
@@ -20,7 +73,7 @@ paths:
       summary: Read the entire set of people, sorted by last name
       description: Read the entire set of people, sorted by last name
       responses:
-        200:
+        "200":
           description: Successfully read people set operation
           schema:
             type: array
@@ -67,16 +120,9 @@ paths:
           description: Person to create
           required: True
           schema:
-            type: object
-            properties:
-              fname:
-                type: string
-                description: First name of person to create
-              lname:
-                type: string
-                description: Last name of person to create
+            $ref: "#/definitions/PersonCreate"
       responses:
-        201:
+        "201":
           description: Successfully created person
           schema:
             properties:
@@ -107,13 +153,13 @@ paths:
           type: integer
           required: True
       responses:
-        200:
+        "200":
           description: Successfully read person from people data operation
           schema:
             type: object
             properties:
               person_id:
-                type: string
+                type: integer
                 description: Id of the person
               fname:
                 type: string
@@ -155,17 +201,11 @@ paths:
           required: True
         - name: person
           in: body
+          required: True
           schema:
-            type: object
-            properties:
-              fname:
-                type: string
-                description: First name of the person
-              lname:
-                type: string
-                description: Last name of the person
+            $ref: "#/definitions/PersonUpdate"
       responses:
-        200:
+        "200":
           description: Successfully updated person
           schema:
             properties:
@@ -195,8 +235,10 @@ paths:
           description: Id of the person to delete
           required: true
       responses:
-        200:
+        "200":
           description: Successfully deleted a person
+          schema:
+            $ref: "#/definitions/DeleteResponse"
 
   /notes:
     get:
@@ -206,7 +248,7 @@ paths:
       summary: Read the entire set of notes for all people, sorted by timestamp
       description: Read the entire set of notes for all people, sorted by timestamp
       responses:
-        200:
+        "200":
           description: Successfully read notes for all people operation
           schema:
             type: array
@@ -256,13 +298,9 @@ paths:
           description: Text content of the note to create
           required: True
           schema:
-            type: object
-            properties:
-              content:
-                type: string
-                description: Text of the note to create
+            $ref: "#/definitions/NoteWrite"
       responses:
-        201:
+        "201":
           description: Successfully created a note
           schema:
             properties:
@@ -298,7 +336,7 @@ paths:
           type: integer
           required: True
       responses:
-        200:
+        "200":
           description: Successfully read note for a person
           schema:
             type: object
@@ -335,19 +373,16 @@ paths:
           required: True
         - name: note
           in: body
+          required: True
           schema:
-            type: object
-            properties:
-              content:
-                type: string
-                description: Text content of the note to updated
+            $ref: "#/definitions/NoteWrite"
       responses:
-        200:
+        "200":
           description: Successfully updated note
           schema:
             properties:
               note_id:
-                type: string
+                type: integer
                 description: Id of the note associated with a person
               person_id:
                 type: integer
@@ -377,7 +412,7 @@ paths:
           type: integer
           required: True
       responses:
-        200:
+        "200":
           description: Successfully deleted a note
-
-
+          schema:
+            $ref: "#/definitions/DeleteResponse"

--- a/flask-connextion-rest/test/test_app.py
+++ b/flask-connextion-rest/test/test_app.py
@@ -1,9 +1,16 @@
 """Runtime and CRUD smoke tests for the Connexion example."""
 
+from pathlib import Path
+
 import pytest
+import yaml
+from openapi_spec_validator import validate
 
 from config import db
 from server import create_app
+
+
+APP_ROOT = Path(__file__).resolve().parents[1]
 
 
 @pytest.fixture()
@@ -26,6 +33,44 @@ def test_landing_page_renders(application):
 
     assert response.status_code == 200
     assert "People" in response.text
+
+
+def test_openapi_document_is_valid():
+    specification = yaml.safe_load((APP_ROOT / "swagger.yml").read_text())
+
+    validate(specification)
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"fname": "Ada"},
+        {"fname": "", "lname": "Lovelace"},
+        {"fname": "Ada", "lname": "Lovelace", "role": "programmer"},
+    ],
+)
+def test_people_create_contract_rejects_invalid_payloads(application, payload):
+    response = application.test_client().post("/api/people", json=payload)
+
+    assert response.status_code == 400
+
+
+def test_write_contract_rejects_empty_updates(application):
+    client = application.test_client()
+    created_person = client.post(
+        "/api/people",
+        json={"fname": "Ada", "lname": "Lovelace"},
+    )
+    person_id = created_person.json()["person_id"]
+
+    empty_person_update = client.put(f"/api/people/{person_id}", json={})
+    missing_note_content = client.post(
+        f"/api/people/{person_id}/notes",
+        json={},
+    )
+
+    assert empty_person_update.status_code == 400
+    assert missing_note_content.status_code == 400
 
 
 def test_people_and_notes_crud_contract(application):
@@ -62,6 +107,7 @@ def test_people_and_notes_crud_contract(application):
 
     deleted_note = client.delete(f"/api/people/{person_id}/notes/{note_id}")
     assert deleted_note.status_code == 200
+    assert deleted_note.json() == {"message": f"Note {note_id} deleted"}
 
     updated_person = client.put(
         f"/api/people/{person_id}",
@@ -72,4 +118,5 @@ def test_people_and_notes_crud_contract(application):
 
     deleted_person = client.delete(f"/api/people/{person_id}")
     assert deleted_person.status_code == 200
+    assert deleted_person.json() == {"message": f"Person {person_id} deleted"}
     assert client.get(f"/api/people/{person_id}").status_code == 404


### PR DESCRIPTION
## Summary

- make the Swagger document the executable request and response contract
- reject missing, empty, oversized, and undeclared person fields before persistence
- require note content and align non-null SQLAlchemy ownership fields
- return documented JSON deletion responses and enable Connexion response validation
- add OpenAPI validity and negative contract tests
- document the maintained contract boundary in both READMEs

## Architecture contract

The route owns person_id for nested note writes. Clients submit note content only; Marshmallow treats person_id as output-only, while SQLAlchemy requires it at persistence time. The OpenAPI request schema, serializers, and database constraints now describe the same ownership model.

## Validation

- Python 3.14: 7 pytest tests passed
- OpenAPI validator: swagger.yml OK
- compileall: passed
- pip check: no broken requirements
- pip-audit 2.10.1: no known vulnerabilities
- git diff --check: passed

## Dependency review

Direct pins were refreshed on main immediately before this branch. A package-index check found only transitive lock updates. The repository requires Linux lock generation, and the local Docker daemon was unavailable, so this PR intentionally avoids a platform-unsafe lock rewrite. Renovate remains the source for direct dependency updates.