### PR TITLE
Make uv lock checks release-stable

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,9 @@ PATH="$PWD/.lock-venv/bin:$PATH" ./scripts/compile-python-locks.sh
 The script always resolves for Linux and Python 3.14, even when run on macOS, so
 environment-marked dependencies such as SQLAlchemy's `greenlet` support remain in the deployment
 artifacts. Its `--check` mode compiles into a temporary directory and never rewrites the checkout.
-CI runs the same check on Ubuntu and rejects stale or non-reproducible locks.
+The temporary output starts from the committed lock, so CI verifies that the reviewed solution is
+still valid without silently upgrading unrelated transitive dependencies. CI runs the same check on
+Ubuntu and rejects stale or non-reproducible locks.
 
 The `uv` version is also pinned in [`renovate.json`](renovate.json). Keep the lock header's
 `uv pip compile` command intact: Renovate reads that command to find each `requirements.in` source

--- a/scripts/compile-python-locks.sh
+++ b/scripts/compile-python-locks.sh
@@ -38,6 +38,9 @@ for application in "${APPLICATIONS[@]}"; do
   output_file="requirements.txt"
   if [[ -n "$temporary_directory" ]]; then
     output_file="$temporary_directory/$application-requirements.txt"
+    # Seed uv with the committed lock so --check verifies the reviewed solution
+    # instead of upgrading unrelated transitive packages released afterward.
+    cp "$lock_file" "$output_file"
   fi
 
   (


### PR DESCRIPTION
## Summary

- seed `uv pip compile` check outputs from the committed locks
- keep CI focused on validity and reproducibility of the reviewed solution
- document why new unrelated transitive releases do not invalidate a lock

## Why

PR #181 regenerated its intended `httpx2` lock successfully, but a subsequent local check failed only because NumPy 2.5.2 was released after the lock was reviewed. The check wrote to an empty temporary output, so uv upgraded unrelated packages while checking. Normal uv compilation preserves pins when the output file already exists; check mode should do the same.

## Validation

- `bash -n scripts/compile-python-locks.sh`
- `git diff --check`
- `./scripts/compile-python-locks.sh --check` with uv 0.12.3, Linux/Python 3.14 targeting, and the now-older NumPy 2.5.1 pins

## Merge order

Merge this before revalidating and merging Renovate PR #181.
