### PR TITLE
Reject hidden Unicode characters in tracked text

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,13 @@ permissions:
   contents: read
 
 jobs:
+  repository-hygiene:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - run: python3 scripts/check-hidden-unicode.py
+
   python-locks:
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/README.md
+++ b/README.md
@@ -99,8 +99,11 @@ curl --fail --silent --show-error http://localhost:5000/healthz
 docker compose down --volumes
 ```
 
-The full CI workflow also validates [`renovate.json`](renovate.json). A green job for one sample is
-not evidence that another sample or an archival directory is supported.
+The full CI workflow also validates [`renovate.json`](renovate.json) and runs
+[`scripts/check-hidden-unicode.py`](scripts/check-hidden-unicode.py). The latter rejects invisible
+Unicode formatting and spacing characters in tracked text files; use an explicit HTML entity such
+as `&nbsp;` when non-breaking layout is intentional. A green job for one sample is not evidence that
+another sample or an archival directory is supported.
 
 ## Architecture Principles
 
@@ -125,7 +128,7 @@ Core project documentation:
 1. Work in one application scope.
 2. Update its source dependency file and compiled lock together when dependencies change.
 3. Run `./scripts/compile-python-locks.sh --check`, then run the application-specific
-   tests, dependency check, audit, and container gates.
+   tests, dependency check, audit, container gates, and `python3 scripts/check-hidden-unicode.py`.
 4. Document whether the change affects only one sample or a shared repository contract.
 5. Open a focused pull request with the exact validation evidence.
 

--- a/flask-bootstrap/app/templates/flask_user/change_password.html
+++ b/flask-bootstrap/app/templates/flask_user/change_password.html
@@ -15,9 +15,9 @@
           <i class="icon-speech"></i>
         </a>
         <a class="btn" href="./">
-          <i class="icon-graph"></i>  Dashboard</a>
+          <i class="icon-graph"></i> &nbsp;Dashboard</a>
         <a class="btn" href="#">
-          <i class="icon-settings"></i>  Settings</a>
+          <i class="icon-settings"></i> &nbsp;Settings</a>
       </div>
     </li>
   </ol>

--- a/flask-bootstrap/app/templates/pages/admin/create_user.html
+++ b/flask-bootstrap/app/templates/pages/admin/create_user.html
@@ -16,9 +16,9 @@
           <i class="icon-speech"></i>
         </a>
         <a class="btn" href="./">
-          <i class="icon-graph"></i>  Dashboard</a>
+          <i class="icon-graph"></i> &nbsp;Dashboard</a>
         <a class="btn" href="#">
-          <i class="icon-settings"></i>  Settings</a>
+          <i class="icon-settings"></i> &nbsp;Settings</a>
       </div>
     </li>
   </ol>

--- a/flask-bootstrap/app/templates/pages/admin/users.html
+++ b/flask-bootstrap/app/templates/pages/admin/users.html
@@ -16,9 +16,9 @@
           <i class="icon-speech"></i>
         </a>
         <a class="btn" href="./">
-          <i class="icon-graph"></i>  Dashboard</a>
+          <i class="icon-graph"></i> &nbsp;Dashboard</a>
         <a class="btn" href="#">
-          <i class="icon-settings"></i>  Settings</a>
+          <i class="icon-settings"></i> &nbsp;Settings</a>
       </div>
     </li>
   </ol>

--- a/flask-bootstrap/app/templates/pages/member_base.html
+++ b/flask-bootstrap/app/templates/pages/member_base.html
@@ -16,9 +16,9 @@
         <i class="icon-speech"></i>
       </a>
       <a class="btn" href="./">
-        <i class="icon-graph"></i>  Dashboard</a>
+        <i class="icon-graph"></i> &nbsp;Dashboard</a>
       <a class="btn" href="#">
-        <i class="icon-settings"></i>  Settings</a>
+        <i class="icon-settings"></i> &nbsp;Settings</a>
     </div>
   </li>
 </ol>

--- a/flask-bootstrap/app/templates/pages/user_profile_page.html
+++ b/flask-bootstrap/app/templates/pages/user_profile_page.html
@@ -15,9 +15,9 @@
           <i class="icon-speech"></i>
         </a>
         <a class="btn" href="./">
-          <i class="icon-graph"></i>  Dashboard</a>
+          <i class="icon-graph"></i> &nbsp;Dashboard</a>
         <a class="btn" href="#">
-          <i class="icon-settings"></i>  Settings</a>
+          <i class="icon-settings"></i> &nbsp;Settings</a>
       </div>
     </li>
   </ol>

--- a/scripts/check-hidden-unicode.py
+++ b/scripts/check-hidden-unicode.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Reject invisible Unicode characters in tracked text files."""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+
+HIDDEN_UNICODE = re.compile(
+    "[\u00a0\u00ad\u1680\u2000-\u200c\u200e\u200f"
+    "\u2028-\u202f\u205f\u3000\ufeff]"
+)
+
+
+def tracked_files() -> list[Path]:
+    result = subprocess.run(
+        ["git", "ls-files", "-z"],
+        check=True,
+        capture_output=True,
+    )
+    return [Path(path) for path in result.stdout.decode().split("\0") if path]
+
+
+def main() -> int:
+    findings: list[str] = []
+
+    for path in tracked_files():
+        if not path.is_file():
+            continue
+
+        data = path.read_bytes()
+        if b"\0" in data:
+            continue
+
+        try:
+            text = data.decode("utf-8")
+        except UnicodeDecodeError:
+            continue
+
+        for line_number, line in enumerate(text.splitlines(keepends=True), start=1):
+            for match in HIDDEN_UNICODE.finditer(line):
+                findings.append(
+                    f"{path}:{line_number}:{match.start() + 1}: "
+                    f"U+{ord(match.group()):04X}"
+                )
+
+    if findings:
+        print("Hidden Unicode characters found:")
+        print("\n".join(findings))
+        return 1
+
+    print("No hidden Unicode characters found.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Why

Renovate reported hidden Unicode characters on current `main`. The warning traced to ten literal `U+00A0` non-breaking spaces in five Flask-Bootstrap navigation templates. Invisible source characters can obscure diffs and trigger supply-chain tooling warnings even when their current use is only visual spacing.

## Scope

- Replace the ten literal non-breaking spaces with explicit `&nbsp;` entities, preserving the rendered navigation spacing.
- Add `scripts/check-hidden-unicode.py`, aligned with Renovate’s current hidden-character set, to scan tracked UTF-8 text files while skipping binary and non-UTF-8 files.
- Add a focused `repository-hygiene` CI job and document the gate in the root README.

## Non-scope

- No Python dependency, application behavior, route, authentication, database, or container changes.
- No Dash v4 work or other rate-limited Renovate updates.

## Validation

Exact commit: `04b266e`

- Python 3.14.4 exact Flask-Bootstrap lock install passed.
- `pip check` passed.
- Authenticated member/admin flow test passed: 1 test.
- `pip-audit==2.10.1` found no known vulnerabilities.
- Full tracked-file hidden-Unicode scan passed.
- Regression matcher assertion covers the complete configured character set.
- `git diff --check` passed.

## Risk and rollback

Risk is low: HTML renders `&nbsp;` as the same non-breaking space. Rollback is the single commit; the new CI lane is independent of application runtime.

## Review focus

Confirm the HTML entity preserves intended spacing and the scanner excludes binary/non-UTF-8 artifacts while failing on invisible Unicode in tracked text.