### PR TITLE
Document the Flask Apps maintenance model

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ All other directories are historical or experimental examples. They are useful f
 but they are not covered by the current CI matrix and should not be treated as release-ready until
 they gain an explicit test and dependency-maintenance contract.
 
+The repository documentation index and the promotion, demotion, and vendored-asset rules are in
+[`docs/README.md`](docs/README.md).
+
 ## Dependency Contract
 
 Maintained applications use two coordinated files:

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,24 @@
+# Flask Apps documentation
+
+The root [`README.md`](../README.md) is authoritative for supported runtimes,
+maintained applications, dependency locks, validation, and contribution rules.
+Application-specific READMEs remain beside the applications they describe.
+
+## Repository-wide knowledge
+
+- [`maintenance-model.md`](maintenance-model.md) — maintained, experimental,
+  historical, and vendored classifications plus promotion and retirement gates.
+
+## Application documentation
+
+| Application | Local documentation |
+| --- | --- |
+| Flask authentication with Dash | [`flask-auth-dash-bootstrap/README.md`](../flask-auth-dash-bootstrap/README.md) |
+| Flask Bootstrap | [`flask-bootstrap/README.md`](../flask-bootstrap/README.md) |
+| Connexion/OpenAPI | [`flask-connextion-rest/README.md`](../flask-connextion-rest/README.md) |
+| Dash Pages | [`flask-dash-bootstrap/README.md`](../flask-dash-bootstrap/README.md) |
+| Mongo/Celery | [`flask-mongo-celery/README.md`](../flask-mongo-celery/README.md) |
+| SQL/Celery Compose stack | [`flask-sql-celery/README.md`](../flask-sql-celery/README.md) |
+
+Do not treat READMEs inside vendored browser assets as repository guidance. They
+are retained for upstream attribution and runtime-source context.

--- a/docs/maintenance-model.md
+++ b/docs/maintenance-model.md
@@ -1,0 +1,47 @@
+# Application maintenance model
+
+- **Status:** Current repository contract
+- **Last verified:** 2026-08-17
+
+Flask Apps is a collection, not one deployable service. Every directory must be
+classified before its code, dependency graph, or documentation is described as
+supported.
+
+## Classifications
+
+| State | Meaning | Required evidence |
+| --- | --- | --- |
+| Maintained | Included in the root support matrix and current CI | Exact lock, install/check/audit, exercised tests, and required container/Compose gates |
+| Experimental | Owned code with a bounded learning purpose but no complete support contract | Clear status and limitations; never included in release-wide claims |
+| Historical | Preserved example outside the current CI and dependency-maintenance boundary | Status and successor or reactivation requirements |
+| Vendored runtime asset | Third-party source or compiled asset retained for runtime/attribution | Upstream license and provenance; no dormant package-manager graph |
+
+The current maintained list lives in the root [`README.md`](../README.md). This
+document defines the classification rules rather than duplicating that list.
+
+## Promotion to maintained
+
+An experimental or historical application becomes maintained only when one
+focused change provides:
+
+1. a supported Python/runtime boundary;
+2. reviewed direct pins and a complete reproducible installation lock;
+3. dependency conflict and vulnerability checks;
+4. tests that exercise its real application boundary;
+5. container or Compose build, health, and non-root checks when applicable;
+6. an application README with exact run and validation commands; and
+7. a CI lane that runs those gates on the default branch.
+
+A successful import, a passing unit test borrowed from another sample, or a
+README alone is insufficient.
+
+## Retirement or demotion
+
+Demote a maintained application when its runtime is unsupported, lock cannot be
+reproduced, security findings cannot be bounded, or its exercised CI contract is
+removed. Preserve useful history, state the limitation, and identify the
+replacement or the evidence needed for reactivation.
+
+Vendored build manifests and obsolete toolchains should not be restored merely
+to rebuild assets already retained and attributed. Reintroducing a toolchain is
+a new supply-chain decision requiring its own review and validation.


### PR DESCRIPTION
## Summary

- add an index for application-specific documentation
- define maintained, experimental, historical, and vendored classifications
- document promotion and demotion rules for the example applications
- link the maintenance model from the root README

## Why

This repository intentionally preserves examples with different maintenance levels. An explicit model helps readers avoid treating historical demonstrations as supported production templates and gives future cleanup work a reviewable classification contract.

## Validation

- changed Markdown relative-link validation and `git diff --check`: passed
- hidden-Unicode and vendored-asset guards: passed
- Python lock compilation check: passed with the repository-required uv 0.12.5 in an isolated environment
- hosted application and container checks required for the final docs-only head

## Boundaries

Documentation only. No Flask route, vendored asset, dependency, container, or runtime behavior changed. This PR classifies current state; it does not silently promote or retire an application.
